### PR TITLE
Closes #19

### DIFF
--- a/Client/src/app/auth-page/auth-page.component.html
+++ b/Client/src/app/auth-page/auth-page.component.html
@@ -59,6 +59,10 @@
                         required>
                 </div>
 
+                <div *ngIf="this.error" class="section errorContainer">
+                    <span class="errorText">{{ errorText }}</span>
+                </div>
+
                 <button type="submit" class="materialButton" [disabled]=!forgotPasswordForm.valid>Submit</button>
                 <div class="loginText">
                     <span (click)="toggleDefaultLayout()">Login</span>

--- a/Client/src/app/auth-page/auth-page.component.ts
+++ b/Client/src/app/auth-page/auth-page.component.ts
@@ -65,18 +65,21 @@ export class AuthPageComponent implements OnInit {
   }
 
   toggleCreateAccountLayout() {
+    this.clearAlertsAndFields();
     this.default = false;
     this.toggleForgotPassword = false;
     this.toggleCreateAccount = true;
   }
 
   toggleResetPasswordLayout() {
+    this.clearAlertsAndFields();
     this.default = false;
     this.toggleCreateAccount = false;
     this.toggleForgotPassword = true;
   }
 
   toggleDefaultLayout() {
+    this.clearAlertsAndFields();
     this.default = true;
     this.toggleCreateAccount = false;
     this.toggleForgotPassword = false;
@@ -87,6 +90,8 @@ export class AuthPageComponent implements OnInit {
     this.model.EmailAddress = null;
     this.model.Password = null;
     this.forgotPassword.EmailAddress = null;
+    this.newAccount = new Users();
+    this.confirmPasswordRef = null;
   }
 
   onCreateAccount() {
@@ -121,7 +126,6 @@ export class AuthPageComponent implements OnInit {
       if (x.status === 200 || x.status === 204) {
         this.loading = false;
         alert('A link has been sent to your email to reset your password.');
-        this.clearAlertsAndFields();
         this.toggleDefaultLayout();
         return true;
       }

--- a/api/Controllers/AuthController.cs
+++ b/api/Controllers/AuthController.cs
@@ -224,7 +224,7 @@ namespace api.Controllers
             } else
             {
                 this._logger.LogError("Could not retrieve change password token for user: " + user.EmailAddress);
-                return NotFound();
+                return NotFound("Email not found.");
             }
         }
 


### PR DESCRIPTION
Closes #19
- Add error message from API on invalid email when trying to forget password
- Add error text when entering invalid email when attempting to send reset password request
- Clear all auth form fields when changing layout and remove errors